### PR TITLE
Add math mode conversion

### DIFF
--- a/streamdown/plugins/latex.py
+++ b/streamdown/plugins/latex.py
@@ -7,25 +7,87 @@
 # ///
 from pylatexenc.latex2text import LatexNodes2Text
 
+converter = LatexNodes2Text()
+
 class Parser:
   inState = False
+  end = ''
   buffer = ''
+  prefix = ''
+  mode = None
 
 def Plugin(text, state = None, style = None):
   res = True
-  if not Parser.inState:
-    if '$$' in text:
-      Parser.buffer = ''
-      Parser.inState = True
-      text = text[text.index('$$') + 2:]
+  had_conversion = False
+  tokens = [
+    ('$$', '$$', 'block'),
+    ('\\[', '\\]', 'block'),
+    ('\\(', '\\)', 'inline'),
+  ]
 
   if Parser.inState:
-    if not '$$' in text:
+    if Parser.end not in text:
       Parser.buffer += text
-      return res 
+      return res
+
+    before, after = text.split(Parser.end, 1)
+    Parser.buffer += before
+    converted = converter.latex_to_text(Parser.buffer)
+    prefix = Parser.prefix
+    mode = Parser.mode
 
     Parser.inState = False
-    Parser.buffer += text[:text.index('$$')]
+    Parser.end = ''
+    Parser.buffer = ''
+    Parser.prefix = ''
+    Parser.mode = None
 
-    return [LatexNodes2Text().latex_to_text(Parser.buffer)]
+    if mode == 'block' and prefix.strip() == '' and after.strip() == '':
+      return [converted]
 
+    text = prefix + converted + after
+    had_conversion = True
+
+  out = ''
+  current = text
+  changed = False
+
+  while True:
+    best = None
+    for start, end, mode in tokens:
+      idx = current.find(start)
+      if idx == -1:
+        continue
+      if best is None or idx < best[0]:
+        best = (idx, start, end, mode)
+
+    if best is None:
+      out += current
+      break
+
+    idx, start, end, mode = best
+    out += current[:idx]
+    rest = current[idx + len(start):]
+    end_idx = rest.find(end)
+    if end_idx == -1:
+      Parser.inState = True
+      Parser.end = end
+      Parser.buffer = rest
+      Parser.prefix = out
+      Parser.mode = mode
+      return res
+
+    content = rest[:end_idx]
+    after = rest[end_idx + len(end):]
+    converted = converter.latex_to_text(content)
+
+    if mode == 'block' and out.strip() == '' and after.strip() == '':
+      return [converted]
+
+    out += converted
+    current = after
+    changed = True
+
+  if changed or had_conversion:
+    return out
+  return None

--- a/streamdown/sd.py
+++ b/streamdown/sd.py
@@ -661,18 +661,20 @@ def parse(stream):
             continue
 
         state.buffer = b''
-        """
-        # Run through the plugins first
-        res = latex.Plugin(line, state, Style)
-        if res is True:
-            # This means everything was consumed by our plugin and 
-            # we should continue
-            continue
-        elif res is not None:
-            for row in res:
-                yield row
+        # Run through the plugins first (skip in code blocks)
+        if not state.in_code:
+            res = latex.Plugin(line, state, Style)
+            if res is True:
+                # This means everything was consumed by our plugin and
+                # we should continue
                 continue
-        """
+            elif isinstance(res, str):
+                line = res
+            elif res is not None:
+                for row in res:
+                    yield row
+                    continue
+                continue
         
         # running this here avoids stray |
         # So kimi doesn't newline after the <think> token and it uses some unicode triangle?. They'll 

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,3 +9,6 @@ There's two drivers:
  * line-buffer.sh: Some parts of the parser waits for newlines, and this tool will feed line by line.
 
 They both accept a TIMEOUT env variable
+
+Math conversion tests:
+  python3 tests/test_math_conversion.py

--- a/tests/test_math_conversion.py
+++ b/tests/test_math_conversion.py
@@ -1,0 +1,120 @@
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from streamdown.plugins import latex
+
+
+def reset_parser():
+    latex.Parser.mode = None
+    latex.Parser.end = ""
+    latex.Parser.buffer = ""
+    latex.Parser.prefix = ""
+
+
+def run_lines(lines):
+    output = []
+    in_code = False
+
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            in_code = not in_code
+            output.append(line)
+            continue
+
+        if in_code:
+            output.append(line)
+            continue
+
+        res = latex.Plugin(line)
+        if res is True:
+            continue
+        if isinstance(res, str):
+            output.append(res)
+        elif res is not None:
+            output.extend(res)
+        else:
+            output.append(line)
+
+    return output
+
+
+class MathConversionTests(unittest.TestCase):
+    def setUp(self):
+        reset_parser()
+
+    def test_inline_parens(self):
+        text = "".join(run_lines(["Inline \\(a+b\\) test.\n"]))
+        self.assertIn("a+b", text)
+        self.assertNotIn("\\(", text)
+        self.assertNotIn("\\)", text)
+
+    def test_multiple_inline_segments(self):
+        text = "".join(run_lines(["Mix \\(a\\) and \\(b\\).\n"]))
+        self.assertIn("a", text)
+        self.assertIn("b", text)
+        self.assertNotIn("\\(", text)
+        self.assertNotIn("\\)", text)
+
+    def test_block_brackets_multiline(self):
+        text = "".join(run_lines(["\\[\n", "a^2 + b^2\n", "\\]\n"]))
+        self.assertIn("a^2 + b^2", text)
+        self.assertNotIn("\\[", text)
+        self.assertNotIn("\\]", text)
+
+    def test_block_dollars_same_line(self):
+        text = "".join(run_lines(["$$ a+b $$\n"]))
+        self.assertIn("a+b", text)
+        self.assertNotIn("$$", text)
+
+    def test_multiple_blocks_same_line(self):
+        text = "".join(run_lines(["Eq $$a$$ and $$b$$.\n"]))
+        self.assertIn("a", text)
+        self.assertIn("b", text)
+        self.assertNotIn("$$", text)
+
+    def test_inline_with_block_markers(self):
+        text = "".join(run_lines(["Text $$a$$ more.\n"]))
+        self.assertIn("Text", text)
+        self.assertIn("a", text)
+        self.assertIn("more", text)
+        self.assertNotIn("$$", text)
+
+    def test_streamed_inline_across_lines(self):
+        text = "".join(run_lines(["Before \\(a\n", "b\\) after.\n"]))
+        self.assertIn("Before", text)
+        compact = "".join(text.split())
+        self.assertIn("ab", compact)
+        self.assertIn("after", text)
+        self.assertNotIn("\\(", text)
+        self.assertNotIn("\\)", text)
+
+    def test_unclosed_inline_buffers(self):
+        output = run_lines(["Start \\(a+b\n"])
+        self.assertEqual(output, [])
+
+    def test_non_math_line_unchanged(self):
+        text = "".join(run_lines(["No math here.\n"]))
+        self.assertEqual(text, "No math here.\n")
+
+    def test_code_block_skips_conversion(self):
+        text = "".join(
+            run_lines(
+                [
+                    "```python\n",
+                    "x = \"\\\\(a+b\\\\)\"\n",
+                    "```\n",
+                ]
+            )
+        )
+        self.assertIn("\\\\(", text)
+        self.assertIn("\\\\)", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add math mode handling for `$$...$$`, `\[...\]`, and `\(...\)` with streaming-safe buffering
- skip math conversion inside code blocks to avoid altering code samples
- add a focused math conversion test suite

## Testing
- python3 tests/test_math_conversion.py
